### PR TITLE
Fix double text entry and typo in `github-introduction-products`

### DIFF
--- a/github/github-introduction-products/includes/2-what-are-github-products.md
+++ b/github/github-introduction-products/includes/2-what-are-github-products.md
@@ -24,14 +24,12 @@ This is often the product version that comes to mind when thinking of GitHub. Gi
 Below is a breakdown of the features included with GitHub Free:
 
 - Unlimited public/private repositories
-- 2,000 Actions automation minutes/month (_Free for public repositories_)
-- 500MB of Packages storage (_Free for public repositories_)
 - New Issues & Projects (in limited beta)
 - GitHub Community Support
 - Dependabot alerts
 - Two-factor authentication enforcement
-- 2,000 GitHub Actions minutes (_Number of free minutes for private repositories_)
-- 500 MB GitHub Packages storage (_Number of free minutes for private repositories_)
+- 2,000 GitHub Actions minutes (_Number of free minutes for private repositories_), free for public repositories
+- 500 MB GitHub Packages storage (_Number of free minutes for private repositories_), free for public repositories
 
 For a more comprehensive list of features, please refer to [GitHub's pricing page](https://github.com/pricing).
 

--- a/github/github-introduction-products/includes/3-how-licensing-works.md
+++ b/github/github-introduction-products/includes/3-how-licensing-works.md
@@ -38,7 +38,7 @@ GitHub calculates your storage usage for each month based on hourly usage during
 720 GB-Hours + 6,048 GB-Hours = 6,768 GB-Hours
 6,768 GB-Hours / (744 hours per month) = 9.0967 GB-Months
 
-At the end of the month, GitHub rounds your storage to the nearest megabyte. Therefore, your storage usage for March would be 9.097 GB.
+At the end of the month, GitHub rounds your storage to the nearest megabyte. Therefore, your storage usage for March would be 9.067 GB.
 
 If your account's usage surpasses these limits and you have set a spending limit above $0, you incur an additional fee per gigabyte of storage used per month.
 


### PR DESCRIPTION
Spotted these as I was going through the docs, decided to send in the PR to help out